### PR TITLE
Split shared plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ subprojects {
 	// Remove Kotlin from all subprojects except 'shared'
 	tasks {
 		shadowJar {
-			if (this@subprojects.name != "shared") {
+			if (this@subprojects.name != "lib") {
 				dependencies {
 					exclude(dependency("org.jetbrains.kotlin:.*"))
 				}

--- a/plugins/chat/build.gradle.kts
+++ b/plugins/chat/build.gradle.kts
@@ -1,10 +1,9 @@
 repositories {
-	maven("https://repo.dmulloy2.net/repository/public/")
 	maven("https://jitpack.io")
 }
 
 dependencies {
+	compileOnly(project(":lib"))
 	compileOnly(project(":shared"))
 	compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
-	compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT")
 }

--- a/plugins/database/build.gradle.kts
+++ b/plugins/database/build.gradle.kts
@@ -1,0 +1,11 @@
+val exposedVersion: String by project
+
+dependencies {
+	compileOnly(project(":lib"))
+
+	compileOnly("org.jetbrains.exposed:exposed-core:$exposedVersion")
+	compileOnly("org.jetbrains.exposed:exposed-dao:$exposedVersion")
+	compileOnly("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
+	compileOnly("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
+	compileOnly("com.h2database:h2:2.1.214")
+}

--- a/plugins/database/src/main/kotlin/fr/pickaria/database/Logger.kt
+++ b/plugins/database/src/main/kotlin/fr/pickaria/database/Logger.kt
@@ -1,4 +1,4 @@
-package fr.pickaria.shared
+package fr.pickaria.database
 
 import org.bukkit.Bukkit.getLogger
 import org.jetbrains.exposed.sql.SqlLogger

--- a/plugins/database/src/main/kotlin/fr/pickaria/database/Main.kt
+++ b/plugins/database/src/main/kotlin/fr/pickaria/database/Main.kt
@@ -1,0 +1,13 @@
+package fr.pickaria.database
+
+import org.bukkit.plugin.java.JavaPlugin
+import org.jetbrains.exposed.sql.Database
+
+class Main : JavaPlugin() {
+	private lateinit var database: Database
+
+	override fun onEnable() {
+		super.onEnable()
+		database = openDatabase(dataFolder.absolutePath + "/database")
+	}
+}

--- a/plugins/database/src/main/kotlin/fr/pickaria/database/database.kt
+++ b/plugins/database/src/main/kotlin/fr/pickaria/database/database.kt
@@ -1,7 +1,7 @@
-package fr.pickaria.shared
+package fr.pickaria.database
 
-import fr.pickaria.shared.models.BankAccounts
-import fr.pickaria.shared.models.Jobs
+import fr.pickaria.database.models.BankAccounts
+import fr.pickaria.database.models.Jobs
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction

--- a/plugins/database/src/main/kotlin/fr/pickaria/database/models/BankAccounts.kt
+++ b/plugins/database/src/main/kotlin/fr/pickaria/database/models/BankAccounts.kt
@@ -1,6 +1,5 @@
-package fr.pickaria.shared.models
+package fr.pickaria.database.models
 
-import fr.pickaria.shared.BukkitLogger
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.transactions.transaction

--- a/plugins/database/src/main/kotlin/fr/pickaria/database/models/Jobs.kt
+++ b/plugins/database/src/main/kotlin/fr/pickaria/database/models/Jobs.kt
@@ -1,4 +1,4 @@
-package fr.pickaria.shared.models
+package fr.pickaria.database.models
 
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq

--- a/plugins/database/src/main/resources/plugin.yml
+++ b/plugins/database/src/main/resources/plugin.yml
@@ -1,0 +1,7 @@
+name: PickariaDatabase
+version: 1.0
+api-version: 1.19
+main: fr.pickaria.database.Main
+author: Quozul
+depend:
+  - PickariaShared

--- a/plugins/economy/build.gradle.kts
+++ b/plugins/economy/build.gradle.kts
@@ -3,6 +3,8 @@ repositories {
 }
 
 dependencies {
+	compileOnly(project(":lib"))
+	compileOnly(project(":database"))
 	compileOnly(project(":shared"))
 	compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
 }

--- a/plugins/economy/src/main/kotlin/fr/pickaria/economy/BalanceTopCommand.kt
+++ b/plugins/economy/src/main/kotlin/fr/pickaria/economy/BalanceTopCommand.kt
@@ -1,6 +1,6 @@
 package fr.pickaria.economy
 
-import fr.pickaria.shared.models.BankAccount
+import fr.pickaria.database.models.BankAccount
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.minimessage.tag.Tag

--- a/plugins/economy/src/main/kotlin/fr/pickaria/economy/PickariaEconomy.kt
+++ b/plugins/economy/src/main/kotlin/fr/pickaria/economy/PickariaEconomy.kt
@@ -1,6 +1,6 @@
 package fr.pickaria.economy
 
-import fr.pickaria.shared.models.BankAccount
+import fr.pickaria.database.models.BankAccount
 import net.milkbowl.vault.economy.AbstractEconomy
 import net.milkbowl.vault.economy.EconomyResponse
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType

--- a/plugins/job/build.gradle.kts
+++ b/plugins/job/build.gradle.kts
@@ -3,6 +3,8 @@ repositories {
 }
 
 dependencies {
+	compileOnly(project(":lib"))
+	compileOnly(project(":database"))
 	compileOnly(project(":shared"))
 	compileOnly(project(":economy"))
 	compileOnly(project(":menu"))

--- a/plugins/job/src/main/kotlin/fr/pickaria/job/JobCommand.kt
+++ b/plugins/job/src/main/kotlin/fr/pickaria/job/JobCommand.kt
@@ -1,7 +1,7 @@
 package fr.pickaria.job
 
+import fr.pickaria.database.models.Job
 import fr.pickaria.menu.menuController
-import fr.pickaria.shared.models.Job
 import org.bukkit.command.Command
 import org.bukkit.command.CommandExecutor
 import org.bukkit.command.CommandSender

--- a/plugins/job/src/main/kotlin/fr/pickaria/job/JobController.kt
+++ b/plugins/job/src/main/kotlin/fr/pickaria/job/JobController.kt
@@ -1,9 +1,9 @@
 package fr.pickaria.job
 
+import fr.pickaria.database.models.Job
 import fr.pickaria.job.events.JobAscentEvent
 import fr.pickaria.job.events.JobLevelUpEvent
 import fr.pickaria.job.jobs.*
-import fr.pickaria.shared.models.Job
 import org.bukkit.Bukkit
 import org.bukkit.Bukkit.getServer
 import org.bukkit.boss.BarColor

--- a/plugins/job/src/main/kotlin/fr/pickaria/job/JobMenu.kt
+++ b/plugins/job/src/main/kotlin/fr/pickaria/job/JobMenu.kt
@@ -1,8 +1,8 @@
 package fr.pickaria.job
 
+import fr.pickaria.database.models.Job
 import fr.pickaria.menu.BaseMenu
 import fr.pickaria.menu.MenuLore
-import fr.pickaria.shared.models.Job
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextDecoration

--- a/plugins/job/src/main/kotlin/fr/pickaria/job/JobPayment.kt
+++ b/plugins/job/src/main/kotlin/fr/pickaria/job/JobPayment.kt
@@ -1,6 +1,6 @@
 package fr.pickaria.job
 
-import fr.pickaria.shared.models.Job
+import fr.pickaria.database.models.Job
 import net.kyori.adventure.text.Component
 import net.milkbowl.vault.economy.EconomyResponse
 import org.bukkit.Sound

--- a/plugins/lib/build.gradle.kts
+++ b/plugins/lib/build.gradle.kts
@@ -1,0 +1,17 @@
+val exposedVersion: String by project
+
+plugins {
+	kotlin("plugin.serialization") version "1.7.20"
+}
+
+dependencies {
+	implementation(kotlin("stdlib"))
+	implementation(kotlin("reflect"))
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+
+	implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
+	implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
+	implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
+	implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
+	implementation("com.h2database:h2:2.1.214")
+}

--- a/plugins/lib/src/main/kotlin/fr/pickaria/lib/Main.kt
+++ b/plugins/lib/src/main/kotlin/fr/pickaria/lib/Main.kt
@@ -1,0 +1,5 @@
+package fr.pickaria.lib
+
+import org.bukkit.plugin.java.JavaPlugin
+
+class Main : JavaPlugin()

--- a/plugins/lib/src/main/resources/plugin.yml
+++ b/plugins/lib/src/main/resources/plugin.yml
@@ -1,0 +1,7 @@
+name: PickariaLib
+version: 1.0
+api-version: 1.19
+main: fr.pickaria.lib.Main
+author: Quozul
+depend:
+  - PickariaShared

--- a/plugins/menu/build.gradle.kts
+++ b/plugins/menu/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-	compileOnly(project(":shared"))
+	compileOnly(project(":lib"))
 	compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 	compileOnly(kotlin("reflect"))
 }

--- a/plugins/potion/build.gradle.kts
+++ b/plugins/potion/build.gradle.kts
@@ -1,3 +1,3 @@
 dependencies {
-	compileOnly(project(":shared"))
+	compileOnly(project(":lib"))
 }

--- a/plugins/shared/build.gradle.kts
+++ b/plugins/shared/build.gradle.kts
@@ -1,23 +1,8 @@
-val exposedVersion: String by project
-
 repositories {
 	maven("https://jitpack.io")
 }
 
-plugins {
-	kotlin("plugin.serialization") version "1.7.20"
-}
-
 dependencies {
-	implementation(kotlin("stdlib"))
-	implementation(kotlin("reflect"))
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-
-	implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
-	implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
-	implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
-	implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
-	implementation("com.h2database:h2:2.1.214")
-
+	compileOnly(project(":lib"))
 	compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
 }

--- a/plugins/shared/src/main/kotlin/fr/pickaria/shared/Main.kt
+++ b/plugins/shared/src/main/kotlin/fr/pickaria/shared/Main.kt
@@ -1,16 +1,5 @@
 package fr.pickaria.shared
 
 import org.bukkit.plugin.java.JavaPlugin
-import org.jetbrains.exposed.sql.Database
 
-class Main : JavaPlugin() {
-	private lateinit var database: Database
-
-	override fun onEnable() {
-		super.onEnable()
-
-		database = openDatabase(dataFolder.absolutePath + "/database")
-
-		logger.info("Shared plugin loaded!")
-	}
-}
+class Main : JavaPlugin()

--- a/scripts/create-plugin.sh
+++ b/scripts/create-plugin.sh
@@ -62,7 +62,7 @@ repositories {
 }
 
 dependencies {
-	compileOnly(project(":shared"))
+	compileOnly(project(":lib"))
 	compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
 	compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT")
 }
@@ -77,7 +77,7 @@ repositories {
 }
 
 dependencies {
-	compileOnly(project(":shared"))
+	compileOnly(project(":lib"))
 	compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
 }
 EOF
@@ -91,14 +91,14 @@ repositories {
 }
 
 dependencies {
-	compileOnly(project(":shared"))
+	compileOnly(project(":lib"))
 	compileOnly("com.comphenix.protocol:ProtocolLib:5.0.0-SNAPSHOT")
 }
 EOF
 else
   cat > plugins/$plugin_name/build.gradle.kts << EOF
 dependencies {
-	compileOnly(project(":shared"))
+	compileOnly(project(":lib"))
 }
 EOF
 fi

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,10 @@
 rootProject.name = "plugin-collection"
-include("economy", "shared", "menu", "job", "chat", "potion")
+include("economy", "shared", "menu", "job", "chat", "potion", "lib", "database")
 project(":economy").projectDir = File("plugins/economy")
 project(":shared").projectDir = File("plugins/shared")
 project(":menu").projectDir = File("plugins/menu")
 project(":job").projectDir = File("plugins/job")
 project(":chat").projectDir = File("plugins/chat")
 project(":potion").projectDir = File("plugins/potion")
+project(":lib").projectDir = File("plugins/lib")
+project(":database").projectDir = File("plugins/database")


### PR DESCRIPTION
Séparation du plugin shared en 3 plugins : 
- `database` : gère la base de données
- `lib` : contient uniquement les bibliothèques
- `shared` : contient des fonctions et classes partagées